### PR TITLE
fix: remove wrong space when get eye_features var

### DIFF
--- a/scene/talking_dataset_readers.py
+++ b/scene/talking_dataset_readers.py
@@ -357,7 +357,7 @@ def readTalkingPortraitDatasetInfo(path, white_background, eval, extension=".jpg
     # load action units
     import pandas as pd
     au_blink_info=pd.read_csv(os.path.join(path, 'au.csv'))
-    eye_features = au_blink_info[' AU45_r'].values
+    eye_features = au_blink_info['AU45_r'].values
     
     
     ply_path = os.path.join(path, "fused.ply")


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/2bcab9a3-25f4-4524-8e9e-0dcfca97315f)
![image](https://github.com/user-attachments/assets/f60410ce-3ab0-42cd-bbc0-85851d9e77fc)

When running train.py, there will be a KeyError.
We can find it because there is a wrong and extra space when using "AU45_r" to  get the values of "au_blink_info" array from the Traceback info. 
```
eye_features = au_blink_info[' AU45_r'].values
```